### PR TITLE
Display the list of authors in a readable way.

### DIFF
--- a/src/bibtex_js.js
+++ b/src/bibtex_js.js
@@ -350,18 +350,27 @@ function BibtexDisplay() {
         return value;
     }
 
-    this.displayAuthor = function(string) {
+    this.displayAuthor = function(string, firstReversed) {
         string = string.replace(/[ ]*[\n\t][ ]*/g, " ");
         string = string.replace(/[ ]+/g, " ");
         var arrayString = string.split(new RegExp("[\\s]+and[\\s]+"));
-        var newString = arrayString[0];
-        for (i = 1; i < arrayString.length; i++) {
-            if (i + 1 >= arrayString.length) {
-                newString += ", and " + arrayString[i];
+        var newString = ''
+        $.each(arrayString, function(index, item) {
+            if (index == 0 && firstReversed) {
+                // First author should be in 'Last, First' style
+                newString += item;
             } else {
-                newString += ", " + arrayString[i];
+                // Other authors should be in 'First Last' style
+                var name = item.split(new RegExp(",\\s"));
+                newString += name[1] + " " + name[0];
             }
-        }
+            // Last author is separated with ', and'
+            if (index == arrayString.length - 2) {
+                newString += ", and ";
+            } else if (index <= arrayString.length - 3) {
+                newString += ", ";
+            }
+        }); 
         return newString;
     }
 
@@ -434,7 +443,9 @@ function BibtexDisplay() {
             }
 
             if (key == "AUTHOR") {
-                value = this.displayAuthor(this.fixValue(value));
+                value = this.displayAuthor(this.fixValue(value), true);
+            } else if (key == "COLLABORATOR") {
+                value = this.displayAuthor(this.fixValue(value), false);
             } else if (key == "PAGES") {
                 value = value.replace("--", "-");
             } else if (key == "DATE") {

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ test('Check Entries', async t => {
         }).innerText).eql('Programming languages')
         .expect(await entry0.find('.author', {
             index: 0
-        }).innerText).eql('Sammet, J.E., and Hemmendinger, D.')
+        }).innerText).eql('Sammet, J.E., and D. Hemmendinger')
         .expect(await entry0.find('.year', {
             index: 0
         }).innerText).eql('2003')
@@ -39,7 +39,7 @@ test('Check Entries', async t => {
         }).innerText).eql('Übersetzung objektorientierter Programmiersprachen: Konzepte, abstrakte Maschinen und Praktikum \\glqq Java Compiler\\grqq')
         .expect(await entry1.find('.author', {
             index: 1
-        }).innerText).eql('Bauer, B., and Höllerer, R.')
+        }).innerText).eql('Bauer, B., and R. Höllerer')
         .expect(await entry1.find('.year', {
             index: 1
         }).innerText).eql('1998')
@@ -48,7 +48,7 @@ test('Check Entries', async t => {
         }).innerText).eql('ANTLR: A predicated-LL (k) parser generator')
         .expect(await entry2.find('.author', {
             index: 2
-        }).innerText).eql('Parr, T.J., and Quong, R.W.')
+        }).innerText).eql('Parr, T.J., and R.W. Quong')
         .expect(await entry2.find('.year', {
             index: 2
         }).innerText).eql('1995')


### PR DESCRIPTION
This branch fixes the following points:
 * Displays the authors list in a readable way by formatting the first autor `Last, First` and the others `First Last`
 * Treats the `collaborator` key by the same parsing function with all authors are in the `First Last` style.

Thanks for merging!