### PR TITLE
Implements the logic for a reset button

### DIFF
--- a/demo/FullDemo.html
+++ b/demo/FullDemo.html
@@ -23,14 +23,6 @@
 		    });
 		  }); 
 		});   
-		function reset() {
-			$("select").each(function () {
-			  localStorage.setItem($(this).attr("id"),"");
-			  $(this).val("");
-			}); 
-			$("#searchbar").val("");
-			$("#searchbar").trigger('change');
-		}
     </script>
     
     <style>
@@ -55,7 +47,7 @@
 <div class="container-fluid">
 	<div class="searchbar">
 		<div style="float:left;">
-			<button type="button" class="btn btn-default" onclick="reset()">Reset</button>
+			<button type="button" class="btn btn-default bibtex_reset">Reset</button>
 		</div>
 		<div style="float:left;">
 			<select id="authorselectfirst" class="btn bibtex_search bibtex_author" style="border: 1px solid lightgrey;" extra="first" search="author">

--- a/src/bibtex_js.js
+++ b/src/bibtex_js.js
@@ -912,7 +912,7 @@ function loadExtras() {
     }
 
     //Resets selects when back button is used
-    $("select").each(function() {
+    $("select.bibtex_search").each(function() {
         if (localStorage.getItem($(this).attr("id"))) {
             $(this).val(JSON.parse(localStorage.getItem($(this).attr("id"))));
         }
@@ -930,7 +930,17 @@ function loadExtras() {
             combineSearcher(BibTeXSearcherClass, true);
         }
     });
-
+    
+    $(".bibtex_reset").each(function(i, obj) {
+        $(this).on('click', function(e) {
+            $("select.bibtex_search").each(function () {
+                localStorage.setItem($(this).attr("id"),"");
+                $(this).val("");
+            }); 
+            $("#searchbar").val("");
+            $("#searchbar").trigger('change');
+        });
+    });
 }
 
 function combineSearcher(searcherClass, needToRestart) {

--- a/wiki/extra.md
+++ b/wiki/extra.md
@@ -32,6 +32,11 @@ Adding the `bibtex_search` class to an input tag allows the user to search anyth
 <input type="text" class="bibtex_search" id="searchbar" placeholder="Search publications">
 ```
 
+You might also want to define a reset button, which clears all the choices and text inputs comfortably. Adding the class `bibtex_reset` will take care of the onClick magic.
+```html
+<button type="button" class="bibtex_reset">Reset</button>
+```
+
 ## Variable access:
 
 The class `bibtexVar` prints a bibtex entry value within the tag's attributes. The `extra` field defines what value(s) to use ex., the key associate with bibtex entry `BIBTEXKEY`. In any of the attributes use `+BIBTEXKEY+` for where it should print the value. In our example, the papers are stored with the bibtex key as the file name so the template system will generate the link to the page for each bibtex entry. 


### PR DESCRIPTION
With this change, a reset button for the search forms can be easily placed by adding a button with the `bibtex_reset` class. Example and documentation is updated to fit this change.