### PR TITLE
Fix invalid jquery id names if BIBTEXKEY contain specific chars

### DIFF
--- a/src/bibtex_js.js
+++ b/src/bibtex_js.js
@@ -217,7 +217,7 @@ function BibtexParser() {
     this.entry_body = function(directive) {
         this.currentEntry = this.key();
         this.entries[this.currentEntry] = new Object();
-        this.entries[this.currentEntry]["BIBTEXKEY"] = this.rawCurrentKey;
+        this.entries[this.currentEntry]["BIBTEXKEY"] = this.rawCurrentKey.replace(/[:/.# ]/g,'__');
         if (directive == "@INCOLLECTION") {
             this.entries[this.currentEntry]["BIBTEXTYPE"] = "book chapter";
         } else if (directive == "@INPROCEEDINGS") {


### PR DESCRIPTION
Fix invalid jquery id names if BIBTEXKEY contain specific chars (like…… ':' or '/')

This avoid [bib] link to not work to show the bitex raw code due to invalid id name.
Eg. This append on `2013:IKP:2492408.2492414` generated by some sites similar to ACM portal
EEExplorer...