### PR TITLE
revise the format of displaying two authors

### DIFF
--- a/src/bibtex_js.js
+++ b/src/bibtex_js.js
@@ -456,7 +456,12 @@ function BibtexDisplay() {
         }
 
         // Get conjunction if set in author
-        conjunction = format.attr('conjunction') ? format.attr('conjunction') : ', and';
+        if (searchLength==2) {
+            conjunction = format.attr('conjunction') ? format.attr('conjunction') : ' and';
+        }
+        else {
+        	   conjunction = format.attr('conjunction') ? format.attr('conjunction') : ', and';
+        }
         conjunction = "<span class='bibtex_js_conjunction'>" + conjunction + "</span>";
 
         var newString = "";


### PR DESCRIPTION
For a paper with two authors, FirstAuthor and SecondAuthor, the current version will display it as
"FirstAuthor, and SecondAuthor"
After the change, the new version will display it as
"FirstAuthor and SecondAuthor"